### PR TITLE
Feat: swipe, 학습모드 종료 후의 로직 변경/구현 

### DIFF
--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -8,7 +8,6 @@ export const fetchQuizletById = async (
 ): Promise<StudyQuizletResponse> =>
 	await http.get(`quizlet/study/${quizletId}/${mode}`);
 
-// 학습정보제출 -- 학습하기 결과 제출
 export const createStudyLog = async (
 	studyLogInfo: StudyLogRequest,
 ): Promise<BaseApiResponse> =>

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -1,0 +1,83 @@
+import styled from '@emotion/styled';
+import LanguageIcon from '@mui/icons-material/Language';
+
+interface AnswerCardProps {
+	mode: string;
+	step: number;
+	question?: string;
+	answer?: string;
+	link?: string;
+}
+
+function AnswerCard({ step, question, answer, link }: AnswerCardProps) {
+	return (
+		<Container>
+			<Question>
+				<span>Question {step}. </span>
+				{question}
+			</Question>
+			<Answer>
+				<span>A: </span>
+				{answer}
+			</Answer>
+			{link && (
+				<Link href={link} target="_blank" rel="noopener">
+					<LanguageIcon color="primary" fontSize="small" />
+					<URL>{link}</URL>
+				</Link>
+			)}
+		</Container>
+	);
+}
+
+const Container = styled.div`
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	transition: 0.3s;
+	position: relative;
+`;
+
+const Question = styled.p`
+	font-size: 20px;
+	font-weight: bold;
+	color: var(--primary-color);
+	border-bottom: 1px solid #e9e9e9;
+
+	> span {
+		font-weight: bold;
+		color: var(--primary-color);
+		font-size: 20px;
+		margin: 0;
+	}
+`;
+
+const Answer = styled.p`
+	font-size: 18px;
+
+	> span {
+		font-weight: bold;
+		color: gray;
+	}
+`;
+
+const Link = styled.a`
+	display: flex;
+	gap: 10px;
+	align-items: center;
+	font-size: 14px;
+	position: absolute;
+	bottom: 0;
+
+	:hover > span {
+		color: var(--primary-color);
+	}
+`;
+
+const URL = styled.span`
+	font-style: italic;
+	color: gray;
+`;
+
+export default AnswerCard;

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import LanguageIcon from '@mui/icons-material/Language';
+import { mobileMediaQuery } from '../../utils/mediaQueries';
 
 interface AnswerCardProps {
 	isToggling: boolean;
@@ -58,17 +59,23 @@ const Question = styled.p`
 	color: var(--primary-color);
 	border-bottom: 1px solid #999999;
 	padding-bottom: 10px;
+	${mobileMediaQuery} {
+		font-size: 16px;
+	}
 
 	> span {
 		font-weight: bold;
 		color: var(--primary-color);
-		font-size: 20px;
 		margin: 0;
 	}
 `;
 
 const Answer = styled.p`
+	overflow-y: scroll;
 	font-size: 18px;
+	${mobileMediaQuery} {
+		font-size: 16px;
+	}
 
 	> span {
 		font-weight: bold;

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -56,7 +56,8 @@ const Question = styled.p`
 	font-size: 20px;
 	font-weight: bold;
 	color: var(--primary-color);
-	border-bottom: 1px solid #e9e9e9;
+	border-bottom: 1px solid #999999;
+	padding-bottom: 10px;
 
 	> span {
 		font-weight: bold;

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -71,7 +71,6 @@ const Question = styled.p`
 `;
 
 const Answer = styled.p`
-	overflow-y: scroll;
 	font-size: 18px;
 	${mobileMediaQuery} {
 		font-size: 16px;

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import LanguageIcon from '@mui/icons-material/Language';
 
 interface AnswerCardProps {
+	isToggling: boolean;
 	mode: string;
 	step: number;
 	question?: string;
@@ -9,9 +10,19 @@ interface AnswerCardProps {
 	link?: string;
 }
 
-function AnswerCard({ step, question, answer, link }: AnswerCardProps) {
+interface ContainerProps {
+	isToggling: boolean;
+}
+
+function AnswerCard({
+	isToggling,
+	step,
+	question,
+	answer,
+	link,
+}: AnswerCardProps) {
 	return (
-		<Container>
+		<Container isToggling={isToggling}>
 			<Question>
 				<span>Question {step}. </span>
 				{question}
@@ -30,13 +41,15 @@ function AnswerCard({ step, question, answer, link }: AnswerCardProps) {
 	);
 }
 
-const Container = styled.div`
+const Container = styled.div<ContainerProps>`
+	opacity: ${({ isToggling }) => (isToggling ? 0 : 1)};
+	transition: 0.3s;
 	height: 100%;
 	display: flex;
 	flex-direction: column;
 	gap: 20px;
-	transition: 0.3s;
 	position: relative;
+	transform: rotateY(180deg);
 `;
 
 const Question = styled.p`

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -180,6 +180,9 @@ const Container = styled.div`
 
 const CardContainer = styled.main`
 	perspective: 10000px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 
 	${mobileMediaQuery} {
 		width: 90%;
@@ -199,6 +202,9 @@ const MainCard = styled.div<MainCardProps>`
 		height: 400px;
 	}
 	${desktopMediaQuery} {
+		@media (max-width: 900px) {
+			width: 600px;
+		}
 		width: 800px;
 		height: 500px;
 	}
@@ -232,6 +238,10 @@ const Toggler = styled.div<TogglerProps>`
 		width: 100%;
 	}
 	${desktopMediaQuery} {
+		@media (max-width: 900px) {
+			width: 600px;
+		}
+
 		width: 800px;
 	}
 

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -11,15 +11,15 @@ import {
 	QuestionCard,
 	FinishedCard,
 } from '.';
-import { MIN_SWIPE_DISTANCE } from '../../constants';
+import { MIN_SWIPE_DISTANCE, STUDY_MODE } from '../../constants';
 
 interface CardProps {
 	goToNextCard: (isWrong: boolean, _id: string) => void;
 	goToPrevCard: (_id: string) => void;
 	step: number;
 	isFinished: boolean;
-	questionListToReview: string[];
-	questionListToCorrect: string[];
+	studyMode: keyof typeof STUDY_MODE;
+	quizletId: string;
 	current?: {
 		_id: string;
 		question: string;
@@ -42,8 +42,8 @@ function Card({
 	isFinished,
 	step,
 	current,
-	questionListToReview,
-	questionListToCorrect,
+	studyMode,
+	quizletId,
 }: CardProps) {
 	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);
 	const [isSwiping, setIsSwiping] = useState(false);
@@ -131,10 +131,7 @@ function Card({
 					{isSwiping && <EmptyCard />}
 					{isSwiping && <GhostCard isWrong={isLeftSwipe.current} />}
 					{isFinished ? (
-						<FinishedCard
-							questionListToCorrect={questionListToCorrect}
-							questionListToReview={questionListToReview}
-						/>
+						<FinishedCard quizletId={quizletId} />
 					) : cardMode === 'answer' ? (
 						<AnswerCard
 							isToggling={isToggling}
@@ -183,7 +180,7 @@ const CardContainer = styled.main`
 	perspective: 10000px;
 
 	${mobileMediaQuery} {
-		min-width: 0;
+		width: 90%;
 	}
 `;
 

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -4,6 +4,7 @@ import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import { css } from '@mui/material';
 import AutoStoriesIcon from '@mui/icons-material/AutoStories';
 import { GhostCard, EmptyCard, ControlBox, AnswerCard, QuestionCard } from '.';
+import { MIN_SWIPE_DISTANCE } from '../../constants';
 
 interface CardProps {
 	goToNextCard: () => void;
@@ -20,8 +21,6 @@ interface CardProps {
 interface MainCardProps {
 	cardMode: string;
 }
-
-const MIN_SWIPE_DISTANCE = 100;
 
 function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -3,7 +3,14 @@ import styled from '@emotion/styled';
 import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import { css } from '@mui/material';
 import AutoStoriesIcon from '@mui/icons-material/AutoStories';
-import { ToggleGuideCard, GhostCard, EmptyCard, ControlBox } from '.';
+import {
+	ToggleGuideCard,
+	GhostCard,
+	EmptyCard,
+	ControlBox,
+	AnswerCard,
+	QuestionCard,
+} from '.';
 
 interface CardProps {
 	goToNextCard: () => void;
@@ -24,9 +31,9 @@ interface MainCardProps {
 const MIN_SWIPE_DISTANCE = 50;
 
 function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
-	const [touchStart, setTouchStart] = useState<null | number>(null);
-	const [touchEnd, setTouchEnd] = useState(false);
-	const [togglerHovered, setTogglerHovered] = useState(false);
+	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);
+	const [isSwiping, setIsSwiping] = useState(false);
+	// const [togglerHovered, setTogglerHovered] = useState(false);
 	const [cardMode, setCardMode] = useState<'question' | 'answer'>('question');
 	const [isToggling, setIsToggling] = useState(false);
 	const lastTouch = useRef(0);
@@ -34,7 +41,7 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 
 	/** 질문 or 답안 보기 누르면 카드 내용 변경 */
 	const toggleCard = () => {
-		setTogglerHovered(false);
+		// setTogglerHovered(false);
 		setCardMode((prev) => (prev === 'question' ? 'answer' : 'question'));
 		setIsToggling(true);
 	};
@@ -51,26 +58,25 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 				? (event as React.TouchEvent).touches[0].clientX
 				: (event as React.MouseEvent).clientX;
 
-		setTouchStart(clientX);
+		setSwipeStartX(clientX);
 	};
 
 	/** drag/touch 이벤트로 인한 swipe 애니메이션 종료된 후의 로직  */
 	const endSwipe = (event: React.MouseEvent | React.TouchEvent) => {
-		if (!touchStart) return;
+		if (!swipeStartX) return;
 
 		const clientX =
 			event.type === 'touchend'
 				? lastTouch.current
 				: (event as React.MouseEvent).clientX;
 
-		if (Math.abs(touchStart - clientX) < MIN_SWIPE_DISTANCE) return;
+		if (Math.abs(swipeStartX - clientX) < MIN_SWIPE_DISTANCE) return;
 
-		isLeftSwipe.current = touchStart > clientX ? true : false;
+		isLeftSwipe.current = swipeStartX > clientX ? true : false;
 
-		setTimeout(() => setTouchEnd(false), 800);
-		setTouchEnd(true);
-		setTouchStart(null);
-		// setStep((prev) => prev + 1);
+		setTimeout(() => setIsSwiping(false), 800);
+		setIsSwiping(true);
+		setSwipeStartX(null);
 		goToNextCard();
 	};
 
@@ -78,9 +84,9 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 	const swipeOnClick = (direction: string) => {
 		isLeftSwipe.current = direction === 'incorrect' ? true : false;
 
-		setTimeout(() => setTouchEnd(false), 800);
-		setTouchEnd(true);
-		setTouchStart(null);
+		setTimeout(() => setIsSwiping(false), 800);
+		setIsSwiping(true);
+		setSwipeStartX(null);
 		goToNextCard();
 	};
 
@@ -95,25 +101,32 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 					onTouchMove={recordTouch}
 					onTouchEnd={endSwipe}
 				>
-					<ToggleGuideCard
+					{/* <ToggleGuideCard
 						target={cardMode === 'question' ? 'answer' : 'question'}
 						display={togglerHovered}
-					/>
-					<EmptyCard display={touchEnd || isToggling} />
-					<GhostCard isWrong={isLeftSwipe.current} display={touchEnd} />
+					/> */}
+					{isSwiping && <EmptyCard />}
+					{isSwiping && <GhostCard isWrong={isLeftSwipe.current} />}
 					<MainCardContents
 						cardMode={cardMode}
-						onTransitionEnd={() => setIsToggling(false)}
+						// onTransitionEnd={() => setIsToggling(false)}
 					>
-						<p>
-							{cardMode.slice(0, 1).toUpperCase() + cardMode.slice(1)} {step}.
-						</p>
-						<p>{current && current[cardMode]}</p>
+						{cardMode === 'answer' ? (
+							<AnswerCard
+								mode={cardMode}
+								step={step}
+								question={current?.question}
+								answer={current?.answer}
+								link={current?.link}
+							/>
+						) : (
+							<QuestionCard step={step} question={current?.question} />
+						)}
 					</MainCardContents>
 				</MainCard>
 				<Toggler
-					onMouseOver={() => setTogglerHovered(true)}
-					onMouseOut={() => setTogglerHovered(false)}
+					// onMouseOver={() => setTogglerHovered(true)}
+					// onMouseOut={() => setTogglerHovered(false)}
 					onClick={() => toggleCard()}
 				>
 					<p>{cardMode === 'question' ? '답안 보기' : '질문 보기'}</p>

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -131,7 +131,7 @@ function Card({
 						<GhostCard isWrong={isLeftSwipe.current} cardMode={cardMode} />
 					)}
 					{isFinished ? (
-						<FinishedCard quizletId={quizletId} />
+						<FinishedCard quizletId={quizletId} cardMode={cardMode} />
 					) : cardMode === 'answer' ? (
 						<AnswerCard
 							isToggling={isToggling}

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -70,7 +70,7 @@ function Card({
 
 	/** mousedown/touch 이벤트에 따라 카드 swipe 로직 실행 */
 	const beginSwipe = (event: React.MouseEvent | React.TouchEvent) => {
-		if (isFinished) return;
+		if (isFinished || isSwiping) return;
 
 		const clientX =
 			event.type === 'touchstart'
@@ -106,6 +106,8 @@ function Card({
 
 	/** click 이벤트에 따라 카드 swipe */
 	const swipeOnClick = (direction: string) => {
+		if (isSwiping) return;
+
 		isLeftSwipe.current = direction === 'incorrect' ? true : false;
 
 		setTimeout(() => setIsSwiping(false), 800);

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -174,6 +174,7 @@ const Container = styled.div`
 	flex-direction: column;
 	align-items: center;
 	gap: 30px;
+	overflow-x: hidden;
 `;
 
 const CardContainer = styled.main`

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -14,10 +14,12 @@ import {
 import { MIN_SWIPE_DISTANCE } from '../../constants';
 
 interface CardProps {
-	goToNextCard: () => void;
-	goToPrevCard: () => void;
+	goToNextCard: (isWrong: boolean, _id: string) => void;
+	goToPrevCard: (_id: string) => void;
 	step: number;
 	isFinished: boolean;
+	questionListToReview: string[];
+	questionListToCorrect: string[];
 	current?: {
 		_id: string;
 		question: string;
@@ -40,6 +42,8 @@ function Card({
 	isFinished,
 	step,
 	current,
+	questionListToReview,
+	questionListToCorrect,
 }: CardProps) {
 	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);
 	const [isSwiping, setIsSwiping] = useState(false);
@@ -99,7 +103,7 @@ function Card({
 		setTimeout(() => setIsSwiping(false), 800);
 		setIsSwiping(true);
 		setSwipeStartX(null);
-		goToNextCard();
+		goToNextCard(isLeftSwipe.current, current?._id as string);
 	};
 
 	/** click 이벤트에 따라 카드 swipe */
@@ -109,7 +113,7 @@ function Card({
 		setTimeout(() => setIsSwiping(false), 800);
 		setIsSwiping(true);
 		setSwipeStartX(null);
-		goToNextCard();
+		goToNextCard(isLeftSwipe.current, current?._id as string);
 	};
 
 	return (
@@ -127,7 +131,10 @@ function Card({
 					{isSwiping && <EmptyCard />}
 					{isSwiping && <GhostCard isWrong={isLeftSwipe.current} />}
 					{isFinished ? (
-						<FinishedCard />
+						<FinishedCard
+							questionListToCorrect={questionListToCorrect}
+							questionListToReview={questionListToReview}
+						/>
 					) : cardMode === 'answer' ? (
 						<AnswerCard
 							isToggling={isToggling}
@@ -156,7 +163,7 @@ function Card({
 				</Toggler>
 			</CardContainer>
 			<ControlBox
-				goToPrevCard={goToPrevCard}
+				goToPrevCard={() => goToPrevCard(current?._id as string)}
 				swipe={swipeOnClick}
 				isFinished={isFinished}
 			/>

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -174,7 +174,6 @@ const Container = styled.div`
 	flex-direction: column;
 	align-items: center;
 	gap: 30px;
-	overflow-x: hidden;
 `;
 
 const CardContainer = styled.main`

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -3,13 +3,21 @@ import styled from '@emotion/styled';
 import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import { css } from '@mui/material';
 import AutoStoriesIcon from '@mui/icons-material/AutoStories';
-import { GhostCard, EmptyCard, ControlBox, AnswerCard, QuestionCard } from '.';
+import {
+	GhostCard,
+	EmptyCard,
+	ControlBox,
+	AnswerCard,
+	QuestionCard,
+	FinishedCard,
+} from '.';
 import { MIN_SWIPE_DISTANCE } from '../../constants';
 
 interface CardProps {
 	goToNextCard: () => void;
 	goToPrevCard: () => void;
 	step: number;
+	isFinished: boolean;
 	current?: {
 		_id: string;
 		question: string;
@@ -22,7 +30,17 @@ interface MainCardProps {
 	cardMode: string;
 }
 
-function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
+interface TogglerProps {
+	isFinished: boolean;
+}
+
+function Card({
+	goToNextCard,
+	goToPrevCard,
+	isFinished,
+	step,
+	current,
+}: CardProps) {
 	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);
 	const [isSwiping, setIsSwiping] = useState(false);
 	const [isToggling, setIsToggling] = useState(false);
@@ -32,7 +50,7 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 
 	/** 질문 or 답안 보기 누르면 카드 내용 변경 */
 	const toggleCard = () => {
-		if (isToggling) return;
+		if (isToggling || isFinished) return;
 
 		setCardMode((prev) => (prev === 'question' ? 'answer' : 'question'));
 		setIsToggling(true);
@@ -50,7 +68,7 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 
 	/** mousedown/touch 이벤트에 따라 카드 swipe 로직 실행 */
 	const beginSwipe = (event: React.MouseEvent | React.TouchEvent) => {
-		console.log('drag start', '🔥');
+		if (isFinished) return;
 
 		const clientX =
 			event.type === 'touchstart'
@@ -108,7 +126,9 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 				>
 					{isSwiping && <EmptyCard />}
 					{isSwiping && <GhostCard isWrong={isLeftSwipe.current} />}
-					{cardMode === 'answer' ? (
+					{isFinished ? (
+						<FinishedCard />
+					) : cardMode === 'answer' ? (
 						<AnswerCard
 							isToggling={isToggling}
 							mode={cardMode}
@@ -126,12 +146,20 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 						/>
 					)}
 				</MainCard>
-				<Toggler onClick={() => toggleCard()}>
-					<p>{cardMode === 'question' ? '답안 보기' : '질문 보기'}</p>
-					<AutoStoriesIcon color="inherit" />
+				<Toggler onClick={() => toggleCard()} isFinished={isFinished}>
+					{!isFinished && (
+						<>
+							<p>{cardMode === 'question' ? '답안 보기' : '질문 보기'}</p>
+							<AutoStoriesIcon color="inherit" />
+						</>
+					)}
 				</Toggler>
 			</CardContainer>
-			<ControlBox goToPrevCard={goToPrevCard} swipe={swipeOnClick} />
+			<ControlBox
+				goToPrevCard={goToPrevCard}
+				swipe={swipeOnClick}
+				isFinished={isFinished}
+			/>
 		</Container>
 	);
 }
@@ -181,7 +209,7 @@ const MainCard = styled.div<MainCardProps>`
 	cursor: pointer;
 `;
 
-const Toggler = styled.div`
+const Toggler = styled.div<TogglerProps>`
 	background-color: #999999;
 	border-radius: 0 0 10px 10px;
 	color: #fff;
@@ -202,8 +230,13 @@ const Toggler = styled.div`
 	}
 
 	:hover {
-		color: #eeeeee;
-		background-color: #b1b1b1;
+		${({ isFinished }) =>
+			!isFinished
+				? css`
+						color: #eeeeee;
+						background-color: #b1b1b1;
+				  `
+				: ''}
 	}
 `;
 

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import styled from '@emotion/styled';
 import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import { css } from '@mui/material';
@@ -21,7 +21,7 @@ interface MainCardProps {
 	cardMode: string;
 }
 
-const MIN_SWIPE_DISTANCE = 50;
+const MIN_SWIPE_DISTANCE = 100;
 
 function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);
@@ -39,13 +39,20 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 		setIsToggling(true);
 	};
 
+	/** 카드 toggle transition 종료 후 isToggling 상태 false로 변경 */
+	const displayCardText = () => {
+		setIsToggling(false);
+	};
+
 	/** (For mobile) touchmove 이벤트에 따라 유저의 touch 종료 지점 기록 */
 	const recordTouch = (event: React.TouchEvent) => {
 		lastTouch.current = event.touches[0].clientX;
 	};
 
-	/** drag/touch 이벤트에 따라 카드 swipe 로직 실행 */
+	/** mousedown/touch 이벤트에 따라 카드 swipe 로직 실행 */
 	const beginSwipe = (event: React.MouseEvent | React.TouchEvent) => {
+		console.log('drag start', '🔥');
+
 		const clientX =
 			event.type === 'touchstart'
 				? (event as React.TouchEvent).touches[0].clientX
@@ -54,7 +61,12 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 		setSwipeStartX(clientX);
 	};
 
-	/** drag/touch 이벤트로 인한 swipe 애니메이션 종료된 후의 로직  */
+	/** card 위에서 MouseUp이 발생한 경우 card를 swipe할 마음이 없다고 판단해서 swipe 로직 중단 */
+	const cancelSwipe = () => {
+		setSwipeStartX(null);
+	};
+
+	/** mousedown/touch 이벤트로 인한 swipe 애니메이션 종료된 후의 로직  */
 	const endSwipe = (event: React.MouseEvent | React.TouchEvent) => {
 		if (!swipeStartX) return;
 
@@ -83,18 +95,14 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 		goToNextCard();
 	};
 
-	const displayCardText = () => {
-		setIsToggling(false);
-	};
-
 	return (
-		<>
+		<Container onMouseUp={endSwipe}>
 			<CardContainer>
 				<MainCard
 					onTransitionEnd={displayCardText}
 					cardMode={cardMode}
-					onDragStart={beginSwipe}
-					onDragEnd={endSwipe}
+					onMouseDown={beginSwipe}
+					onMouseUp={cancelSwipe}
 					onTouchStart={beginSwipe}
 					onTouchMove={recordTouch}
 					onTouchEnd={endSwipe}
@@ -125,17 +133,23 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 				</Toggler>
 			</CardContainer>
 			<ControlBox goToPrevCard={goToPrevCard} swipe={swipeOnClick} />
-		</>
+		</Container>
 	);
 }
 
-const CardContainer = styled.main`
+const Container = styled.div`
+	width: 100vw;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	gap: 30px;
+`;
+
+const CardContainer = styled.main`
 	perspective: 10000px;
+
 	${mobileMediaQuery} {
-		width: 100%;
+		min-width: 0;
 	}
 `;
 
@@ -146,6 +160,7 @@ const MainCard = styled.div<MainCardProps>`
 	height: 500px;
 	backface-visibility: visible;
 	border-radius: 10px 10px 0 0;
+
 	${mobileMediaQuery} {
 		width: 100%;
 		height: 400px;
@@ -179,8 +194,13 @@ const Toggler = styled.div`
 	font-weight: 500;
 	cursor: pointer;
 	transition: 0.1s ease-in;
-	width: 100%;
 	height: 40px;
+	${mobileMediaQuery} {
+		width: 100%;
+	}
+	${desktopMediaQuery} {
+		width: 800px;
+	}
 
 	:hover {
 		color: #eeeeee;

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -3,14 +3,7 @@ import styled from '@emotion/styled';
 import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import { css } from '@mui/material';
 import AutoStoriesIcon from '@mui/icons-material/AutoStories';
-import {
-	ToggleGuideCard,
-	GhostCard,
-	EmptyCard,
-	ControlBox,
-	AnswerCard,
-	QuestionCard,
-} from '.';
+import { GhostCard, EmptyCard, ControlBox, AnswerCard, QuestionCard } from '.';
 
 interface CardProps {
 	goToNextCard: () => void;
@@ -33,15 +26,15 @@ const MIN_SWIPE_DISTANCE = 50;
 function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);
 	const [isSwiping, setIsSwiping] = useState(false);
-	// const [togglerHovered, setTogglerHovered] = useState(false);
-	const [cardMode, setCardMode] = useState<'question' | 'answer'>('question');
 	const [isToggling, setIsToggling] = useState(false);
+	const [cardMode, setCardMode] = useState<'question' | 'answer'>('question');
 	const lastTouch = useRef(0);
 	const isLeftSwipe = useRef(false);
 
 	/** 질문 or 답안 보기 누르면 카드 내용 변경 */
 	const toggleCard = () => {
-		// setTogglerHovered(false);
+		if (isToggling) return;
+
 		setCardMode((prev) => (prev === 'question' ? 'answer' : 'question'));
 		setIsToggling(true);
 	};
@@ -90,10 +83,15 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 		goToNextCard();
 	};
 
+	const displayCardText = () => {
+		setIsToggling(false);
+	};
+
 	return (
 		<>
 			<CardContainer>
 				<MainCard
+					onTransitionEnd={displayCardText}
 					cardMode={cardMode}
 					onDragStart={beginSwipe}
 					onDragEnd={endSwipe}
@@ -101,34 +99,27 @@ function Card({ goToNextCard, goToPrevCard, step, current }: CardProps) {
 					onTouchMove={recordTouch}
 					onTouchEnd={endSwipe}
 				>
-					{/* <ToggleGuideCard
-						target={cardMode === 'question' ? 'answer' : 'question'}
-						display={togglerHovered}
-					/> */}
 					{isSwiping && <EmptyCard />}
 					{isSwiping && <GhostCard isWrong={isLeftSwipe.current} />}
-					<MainCardContents
-						cardMode={cardMode}
-						// onTransitionEnd={() => setIsToggling(false)}
-					>
-						{cardMode === 'answer' ? (
-							<AnswerCard
-								mode={cardMode}
-								step={step}
-								question={current?.question}
-								answer={current?.answer}
-								link={current?.link}
-							/>
-						) : (
-							<QuestionCard step={step} question={current?.question} />
-						)}
-					</MainCardContents>
+					{cardMode === 'answer' ? (
+						<AnswerCard
+							isToggling={isToggling}
+							mode={cardMode}
+							step={step}
+							question={current?.question}
+							answer={current?.answer}
+							link={current?.link}
+						/>
+					) : (
+						<QuestionCard
+							isToggling={isToggling}
+							mode={cardMode}
+							step={step}
+							question={current?.question}
+						/>
+					)}
 				</MainCard>
-				<Toggler
-					// onMouseOver={() => setTogglerHovered(true)}
-					// onMouseOut={() => setTogglerHovered(false)}
-					onClick={() => toggleCard()}
-				>
+				<Toggler onClick={() => toggleCard()}>
 					<p>{cardMode === 'question' ? '답안 보기' : '질문 보기'}</p>
 					<AutoStoriesIcon color="inherit" />
 				</Toggler>
@@ -174,35 +165,6 @@ const MainCard = styled.div<MainCardProps>`
 	transform-style: preserve-3d;
 	position: relative;
 	cursor: pointer;
-`;
-
-const MainCardContents = styled.div<MainCardProps>`
-	height: 100%;
-	display: flex;
-	flex-direction: column;
-	gap: 20px;
-	transition: 0.3s;
-	${({ cardMode }) =>
-		cardMode === 'question'
-			? css(`
-        transform: rotateY(0);
-      `)
-			: css(`
-        transform: rotateY(180deg);
-      `)};
-
-	> p:first-of-type {
-		font-weight: bold;
-		color: var(--primary-color);
-		font-size: 20px;
-	}
-
-	> p:nth-of-type(2) {
-		padding: 10px;
-		font-weight: 500;
-		font-size: 18px;
-		color: var(--font-color);
-	}
 `;
 
 const Toggler = styled.div`

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import { css } from '@mui/material';
 import AutoStoriesIcon from '@mui/icons-material/AutoStories';
+import { MIN_SWIPE_DISTANCE } from '../../constants';
 import {
 	GhostCard,
 	EmptyCard,
@@ -11,7 +12,6 @@ import {
 	QuestionCard,
 	FinishedCard,
 } from '.';
-import { MIN_SWIPE_DISTANCE } from '../../constants';
 
 interface CardProps {
 	goToNextCard: (isWrong: boolean, _id: string) => void;
@@ -169,7 +169,7 @@ function Card({
 }
 
 const Container = styled.div`
-	width: 100vw;
+	width: 90vw;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -11,14 +11,13 @@ import {
 	QuestionCard,
 	FinishedCard,
 } from '.';
-import { MIN_SWIPE_DISTANCE, STUDY_MODE } from '../../constants';
+import { MIN_SWIPE_DISTANCE } from '../../constants';
 
 interface CardProps {
 	goToNextCard: (isWrong: boolean, _id: string) => void;
 	goToPrevCard: (_id: string) => void;
 	step: number;
 	isFinished: boolean;
-	studyMode: keyof typeof STUDY_MODE;
 	quizletId: string;
 	current?: {
 		_id: string;
@@ -42,7 +41,6 @@ function Card({
 	isFinished,
 	step,
 	current,
-	studyMode,
 	quizletId,
 }: CardProps) {
 	const [swipeStartX, setSwipeStartX] = useState<null | number>(null);
@@ -129,7 +127,9 @@ function Card({
 					onTouchEnd={endSwipe}
 				>
 					{isSwiping && <EmptyCard />}
-					{isSwiping && <GhostCard isWrong={isLeftSwipe.current} />}
+					{isSwiping && (
+						<GhostCard isWrong={isLeftSwipe.current} cardMode={cardMode} />
+					)}
 					{isFinished ? (
 						<FinishedCard quizletId={quizletId} />
 					) : cardMode === 'answer' ? (

--- a/src/components/study/ControlBox.tsx
+++ b/src/components/study/ControlBox.tsx
@@ -48,7 +48,7 @@ const Container = styled.div<ContainerProps>`
 		isFinished ? 'center' : 'space-between'};
 
 	${mobileMediaQuery} {
-		width: 100%;
+		width: 90%;
 	}
 	${desktopMediaQuery} {
 		width: 800px;

--- a/src/components/study/ControlBox.tsx
+++ b/src/components/study/ControlBox.tsx
@@ -51,6 +51,10 @@ const Container = styled.div<ContainerProps>`
 		width: 90%;
 	}
 	${desktopMediaQuery} {
+		@media (max-width: 900px) {
+			width: 600px;
+		}
+
 		width: 800px;
 	}
 `;

--- a/src/components/study/ControlBox.tsx
+++ b/src/components/study/ControlBox.tsx
@@ -7,34 +7,46 @@ import BeenhereIcon from '@mui/icons-material/Beenhere';
 
 interface ControlBoxProps {
 	swipe: (direction: string) => void;
+	isFinished: boolean;
 	goToPrevCard: () => void;
 }
 
-function ControlBox({ swipe, goToPrevCard }: ControlBoxProps) {
+interface ContainerProps {
+	isFinished: boolean;
+}
+
+function ControlBox({ swipe, isFinished, goToPrevCard }: ControlBoxProps) {
 	return (
-		<Container>
-			<IncorrectSide onClick={() => swipe('incorrect')}>
-				<DragGuideContents>
-					<PlaylistAddIcon color="inherit" fontSize="inherit" />
-					<p>오답노트 등록</p>
-				</DragGuideContents>
-			</IncorrectSide>
+		<Container isFinished={isFinished}>
+			{!isFinished && (
+				<IncorrectSide onClick={() => swipe('incorrect')}>
+					<DragGuideContents>
+						<PlaylistAddIcon color="inherit" fontSize="inherit" />
+						<p>오답노트 등록</p>
+					</DragGuideContents>
+				</IncorrectSide>
+			)}
+
 			<UndoButton size="large" onClick={() => goToPrevCard()}>
 				<UndoIcon fontSize="inherit" />
 			</UndoButton>
-			<CorrectSide onClick={() => swipe('correct')}>
-				<DragGuideContents>
-					<BeenhereIcon color="inherit" fontSize="inherit" />
-					<p>학습 완료</p>
-				</DragGuideContents>
-			</CorrectSide>
+			{!isFinished && (
+				<CorrectSide onClick={() => swipe('correct')}>
+					<DragGuideContents>
+						<BeenhereIcon color="inherit" fontSize="inherit" />
+						<p>학습 완료</p>
+					</DragGuideContents>
+				</CorrectSide>
+			)}
 		</Container>
 	);
 }
 
-const Container = styled.div`
+const Container = styled.div<ContainerProps>`
 	display: flex;
-	justify-content: space-between;
+	justify-content: ${({ isFinished }) =>
+		isFinished ? 'center' : 'space-between'};
+
 	${mobileMediaQuery} {
 		width: 100%;
 	}

--- a/src/components/study/EmptyCard.tsx
+++ b/src/components/study/EmptyCard.tsx
@@ -1,16 +1,10 @@
 import styled from '@emotion/styled';
 
-interface EmptyCardProps {
-	display?: boolean;
+function EmptyCard() {
+	return <Container></Container>;
 }
 
-function EmptyCard({ display }: EmptyCardProps) {
-	return <Container display={display}></Container>;
-}
-
-const Container = styled.div<EmptyCardProps>`
-	/* opacity: ${(props) => (props.display ? 1 : 0)}; */
-	background-color: red;
+const Container = styled.div`
 	width: 100%;
 	height: 100%;
 	display: flex;
@@ -21,7 +15,7 @@ const Container = styled.div<EmptyCardProps>`
 	left: 0;
 	top: 0;
 	z-index: 9999;
-	/* background-color: #fff; */
+	background-color: #fff;
 	border-radius: 10px 10px 0 0;
 `;
 

--- a/src/components/study/EmptyCard.tsx
+++ b/src/components/study/EmptyCard.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 interface EmptyCardProps {
-	display: boolean;
+	display?: boolean;
 }
 
 function EmptyCard({ display }: EmptyCardProps) {
@@ -9,7 +9,8 @@ function EmptyCard({ display }: EmptyCardProps) {
 }
 
 const Container = styled.div<EmptyCardProps>`
-	opacity: ${(props) => (props.display ? 1 : 0)};
+	/* opacity: ${(props) => (props.display ? 1 : 0)}; */
+	background-color: red;
 	width: 100%;
 	height: 100%;
 	display: flex;
@@ -19,8 +20,8 @@ const Container = styled.div<EmptyCardProps>`
 	position: absolute;
 	left: 0;
 	top: 0;
-	z-index: 9998;
-	background-color: #fff;
+	z-index: 9999;
+	/* background-color: #fff; */
 	border-radius: 10px 10px 0 0;
 `;
 

--- a/src/components/study/FinishedCard.tsx
+++ b/src/components/study/FinishedCard.tsx
@@ -10,9 +10,14 @@ import { createStudyLog } from '../../api';
 
 interface FinishedCardProps {
 	quizletId: string;
+	cardMode: string;
 }
 
-function FinishedCard({ quizletId }: FinishedCardProps) {
+interface ContainerProps {
+	cardMode: string;
+}
+
+function FinishedCard({ quizletId, cardMode }: FinishedCardProps) {
 	const navigate = useNavigate();
 
 	const { questionListToCorrect, questionListToReview, mode } = JSON.parse(
@@ -48,7 +53,7 @@ function FinishedCard({ quizletId }: FinishedCardProps) {
 	};
 
 	return (
-		<Container>
+		<Container cardMode={cardMode}>
 			<MainMessage>수고하셨습니다!</MainMessage>
 			<ScoreBox>
 				<Score>
@@ -79,7 +84,10 @@ function FinishedCard({ quizletId }: FinishedCardProps) {
 	);
 }
 
-const Container = styled.div`
+const Container = styled.div<ContainerProps>`
+	transform: rotateY(
+		${({ cardMode }) => (cardMode === 'answer' ? '180deg' : '0')}
+	);
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/components/study/FinishedCard.tsx
+++ b/src/components/study/FinishedCard.tsx
@@ -1,21 +1,51 @@
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import CircularProgress from '@mui/material/CircularProgress';
 import Button from '@mui/material/Button';
 import CreateIcon from '@mui/icons-material/Create';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { ProgressFraction } from '../../components';
+import { mobileMediaQuery } from '../../utils/mediaQueries';
+import { createStudyLog } from '../../api';
 
 interface FinishedCardProps {
-	questionListToReview: string[];
-	questionListToCorrect: string[];
+	quizletId: string;
 }
 
-function FinishedCard({
-	questionListToCorrect,
-	questionListToReview,
-}: FinishedCardProps) {
+function FinishedCard({ quizletId }: FinishedCardProps) {
+	const navigate = useNavigate();
+
+	const { questionListToCorrect, questionListToReview, mode } = JSON.parse(
+		localStorage.getItem(`${quizletId}`)!,
+	);
+
 	const correctCount = questionListToCorrect.length;
 	const totalCount = questionListToCorrect.length + questionListToReview.length;
+
+	const submitStudyLog = async (nextPage: 'wrong' | 'complete') => {
+		localStorage.removeItem(`${quizletId}`);
+
+		const nextUrl =
+			nextPage === 'complete'
+				? `/quizlet/detail/${quizletId}`
+				: `/study/${quizletId}/WRONG`;
+
+		const studyLogRequest = {
+			quizletId,
+			questionListToCorrect,
+			questionListToReview,
+			mode,
+		};
+
+		try {
+			const res = await createStudyLog(studyLogRequest);
+			console.log(res);
+		} catch (error) {
+			console.log(error);
+		}
+
+		navigate(nextUrl);
+	};
 
 	return (
 		<Container>
@@ -28,13 +58,19 @@ function FinishedCard({
 				<MemorizedMessage>암기 완료</MemorizedMessage>
 			</ScoreBox>
 			<ButtonBox>
-				<Button variant="contained" startIcon={<CreateIcon />} color="error">
+				<Button
+					variant="contained"
+					startIcon={<CreateIcon />}
+					color="error"
+					onClick={() => submitStudyLog('wrong')}
+				>
 					오답 학습하기
 				</Button>
 				<Button
 					variant="contained"
 					startIcon={<CheckCircleIcon />}
 					color="primary"
+					onClick={() => submitStudyLog('complete')}
 				>
 					학습 완료
 				</Button>
@@ -85,6 +121,11 @@ const ButtonBox = styled.div`
 		font-weight: bold;
 		font-size: 18px;
 		min-width: 200px;
+
+		${mobileMediaQuery} {
+			font-size: 14px;
+			min-width: 120px;
+		}
 	}
 `;
 

--- a/src/components/study/FinishedCard.tsx
+++ b/src/components/study/FinishedCard.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled';
+import CircularProgress from '@mui/material/CircularProgress';
+import Button from '@mui/material/Button';
+import CreateIcon from '@mui/icons-material/Create';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { ProgressFraction } from '../../components';
+
+function FinishedCard() {
+	return (
+		<Container>
+			<MainMessage>수고하셨습니다!</MainMessage>
+			<ScoreBox>
+				<Score>
+					<StyledCircularProgress variant="determinate" value={80} size={180} />
+					<ProgressFraction numerator={3} denominator={5} />
+				</Score>
+				<MemorizedMessage>암기 완료</MemorizedMessage>
+			</ScoreBox>
+			<ButtonBox>
+				<Button variant="contained" startIcon={<CreateIcon />} color="error">
+					오답 학습하기
+				</Button>
+				<Button
+					variant="contained"
+					startIcon={<CheckCircleIcon />}
+					color="primary"
+				>
+					학습 완료
+				</Button>
+			</ButtonBox>
+		</Container>
+	);
+}
+
+const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: space-around;
+	height: 100%;
+`;
+
+const MainMessage = styled.p`
+	font-weight: bold;
+	font-size: 25px;
+`;
+
+const MemorizedMessage = styled.p`
+	font-weight: bold;
+	font-size: 20px;
+`;
+
+const ScoreBox = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 10px;
+`;
+
+const Score = styled.div`
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 180px;
+	min-width: 180px;
+`;
+
+const ButtonBox = styled.div`
+	display: flex;
+	gap: 20px;
+
+	> button {
+		font-weight: bold;
+		font-size: 18px;
+		min-width: 200px;
+	}
+`;
+
+const StyledCircularProgress = styled(CircularProgress)`
+	position: absolute;
+`;
+
+export default FinishedCard;

--- a/src/components/study/FinishedCard.tsx
+++ b/src/components/study/FinishedCard.tsx
@@ -5,14 +5,25 @@ import CreateIcon from '@mui/icons-material/Create';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { ProgressFraction } from '../../components';
 
-function FinishedCard() {
+interface FinishedCardProps {
+	questionListToReview: string[];
+	questionListToCorrect: string[];
+}
+
+function FinishedCard({
+	questionListToCorrect,
+	questionListToReview,
+}: FinishedCardProps) {
+	const correctCount = questionListToCorrect.length;
+	const totalCount = questionListToCorrect.length + questionListToReview.length;
+
 	return (
 		<Container>
 			<MainMessage>수고하셨습니다!</MainMessage>
 			<ScoreBox>
 				<Score>
 					<StyledCircularProgress variant="determinate" value={80} size={180} />
-					<ProgressFraction numerator={3} denominator={5} />
+					<ProgressFraction numerator={correctCount} denominator={totalCount} />
 				</Score>
 				<MemorizedMessage>암기 완료</MemorizedMessage>
 			</ScoreBox>

--- a/src/components/study/FinishedCard.tsx
+++ b/src/components/study/FinishedCard.tsx
@@ -1,4 +1,5 @@
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
 import CircularProgress from '@mui/material/CircularProgress';
 import Button from '@mui/material/Button';
@@ -19,6 +20,7 @@ interface ContainerProps {
 
 function FinishedCard({ quizletId, cardMode }: FinishedCardProps) {
 	const navigate = useNavigate();
+	const location = useLocation();
 
 	const { questionListToCorrect, questionListToReview, mode } = JSON.parse(
 		localStorage.getItem(`${quizletId}`)!,

--- a/src/components/study/FinishedCard.tsx
+++ b/src/components/study/FinishedCard.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import CircularProgress from '@mui/material/CircularProgress';
 import Button from '@mui/material/Button';
@@ -20,7 +19,6 @@ interface ContainerProps {
 
 function FinishedCard({ quizletId, cardMode }: FinishedCardProps) {
 	const navigate = useNavigate();
-	const location = useLocation();
 
 	const { questionListToCorrect, questionListToReview, mode } = JSON.parse(
 		localStorage.getItem(`${quizletId}`)!,
@@ -28,6 +26,7 @@ function FinishedCard({ quizletId, cardMode }: FinishedCardProps) {
 
 	const correctCount = questionListToCorrect.length;
 	const totalCount = questionListToCorrect.length + questionListToReview.length;
+	const correctScore = (correctCount / totalCount) * 100;
 
 	const submitStudyLog = async (nextPage: 'wrong' | 'complete') => {
 		localStorage.removeItem(`${quizletId}`);
@@ -59,7 +58,11 @@ function FinishedCard({ quizletId, cardMode }: FinishedCardProps) {
 			<MainMessage>수고하셨습니다!</MainMessage>
 			<ScoreBox>
 				<Score>
-					<StyledCircularProgress variant="determinate" value={80} size={180} />
+					<StyledCircularProgress
+						variant="determinate"
+						value={correctScore}
+						size={180}
+					/>
 					<ProgressFraction numerator={correctCount} denominator={totalCount} />
 				</Score>
 				<MemorizedMessage>암기 완료</MemorizedMessage>

--- a/src/components/study/GhostCard.tsx
+++ b/src/components/study/GhostCard.tsx
@@ -3,23 +3,24 @@ import { keyframes, css } from '@emotion/react';
 import { mobileMediaQuery, desktopMediaQuery } from '../../utils/mediaQueries';
 
 interface GhostCardProps {
-	display?: boolean;
 	isWrong: boolean;
+	cardMode: string;
 }
 
 interface ContainerProps {
-	display?: boolean;
 	isWrong: boolean;
+	cardMode: string;
 }
 
 interface ContentsProps {
 	isWrong: boolean;
+	cardMode: string;
 }
 
-function GhostCard({ isWrong, display }: GhostCardProps) {
+function GhostCard({ isWrong, cardMode }: GhostCardProps) {
 	return (
-		<Container display={display} isWrong={isWrong}>
-			<Contents isWrong={isWrong}>
+		<Container isWrong={isWrong} cardMode={cardMode}>
+			<Contents isWrong={isWrong} cardMode={cardMode}>
 				{isWrong ? '오답노트 등록' : '학습 완료'}
 			</Contents>
 		</Container>
@@ -61,7 +62,6 @@ const swipeLeft = keyframes`
 `;
 
 const Container = styled.div<ContainerProps>`
-	/* display: ${(props) => (props.display ? 'block' : 'none')}; */
 	display: block;
 	opacity: 0;
 	transition: 0.1s ease-in;
@@ -82,19 +82,21 @@ const Container = styled.div<ContainerProps>`
 	left: 0;
 	z-index: 9999;
 	cursor: pointer;
-	animation: ${(props) =>
-		props.isWrong
+	animation: ${({ isWrong, cardMode }) =>
+		isWrong
 			? css`
-					${swipeLeft} 0.8s ease
+					${cardMode === 'question' ? swipeLeft : swipeRight} 0.8s ease
 			  `
 			: css`
-					${swipeRight} 0.8s ease
+					${cardMode === 'question' ? swipeRight : swipeLeft} 0.8s ease
 			  `};
 `;
 
 const Contents = styled.div<ContentsProps>`
 	transition: 0.1s ease-in;
-	transform: rotateY(0);
+	transform: rotateY(
+		${({ cardMode }) => (cardMode === 'answer' ? '180deg' : '0')}
+	);
 	width: 100%;
 	height: 100%;
 	display: flex;
@@ -108,7 +110,7 @@ const Contents = styled.div<ContentsProps>`
 	border-radius: 10px 10px 0 0;
 	font-size: 30px;
 	font-weight: bold;
-	color: ${(props) => (props.isWrong ? '#f05757cf' : '#55b855d5')};
+	color: ${({ isWrong }) => (isWrong ? '#f05757cf' : '#55b855d5')};
 	border: ${(props) =>
 		props.isWrong ? '2px solid #f05757cf' : '2px solid #55b855d5'};
 `;

--- a/src/components/study/GhostCard.tsx
+++ b/src/components/study/GhostCard.tsx
@@ -3,12 +3,12 @@ import { keyframes, css } from '@emotion/react';
 import { mobileMediaQuery, desktopMediaQuery } from '../../utils/mediaQueries';
 
 interface GhostCardProps {
-	display: boolean;
+	display?: boolean;
 	isWrong: boolean;
 }
 
 interface ContainerProps {
-	display: boolean;
+	display?: boolean;
 	isWrong: boolean;
 }
 
@@ -61,7 +61,8 @@ const swipeLeft = keyframes`
 `;
 
 const Container = styled.div<ContainerProps>`
-	display: ${(props) => (props.display ? 'block' : 'none')};
+	/* display: ${(props) => (props.display ? 'block' : 'none')}; */
+	display: block;
 	opacity: 0;
 	transition: 0.1s ease-in;
 	border: 1px solid #999999;

--- a/src/components/study/ProgressFraction.tsx
+++ b/src/components/study/ProgressFraction.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { mobileMediaQuery } from '../../utils/mediaQueries';
 
 interface ProgressFractionProps {
 	numerator: number;
@@ -22,6 +23,10 @@ const Container = styled.div`
 		font-weight: bold;
 		font-size: 25px;
 		color: var(--primary-color);
+
+		${mobileMediaQuery} {
+			font-size: 14px;
+		}
 	}
 
 	> p:nth-of-type(2) {

--- a/src/components/study/ProgressFraction.tsx
+++ b/src/components/study/ProgressFraction.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+interface ProgressFractionProps {
+	numerator: number;
+	denominator?: number;
+}
+
+function ProgressFraction({ numerator, denominator }: ProgressFractionProps) {
+	return (
+		<Container>
+			<p>{numerator}</p>
+			<p>/{denominator}</p>
+		</Container>
+	);
+}
+
+const Container = styled.div`
+	display: flex;
+	margin-bottom: 10px;
+
+	> p {
+		font-weight: bold;
+		font-size: 25px;
+		color: var(--primary-color);
+	}
+
+	> p:nth-of-type(2) {
+		color: #000;
+	}
+`;
+
+export default ProgressFraction;

--- a/src/components/study/QuestionCard.tsx
+++ b/src/components/study/QuestionCard.tsx
@@ -1,0 +1,15 @@
+interface QuestionCardProps {
+	step: number;
+	question?: string;
+}
+
+function QuestionCard({ step, question }: QuestionCardProps) {
+	return (
+		<>
+			<p>Question {step}.</p>
+			<p>{question}</p>
+		</>
+	);
+}
+
+export default QuestionCard;

--- a/src/components/study/QuestionCard.tsx
+++ b/src/components/study/QuestionCard.tsx
@@ -1,15 +1,55 @@
+import styled from '@emotion/styled';
+import { css } from '@mui/material';
+
 interface QuestionCardProps {
+	isToggling: boolean;
+	mode: string;
 	step: number;
 	question?: string;
 }
 
-function QuestionCard({ step, question }: QuestionCardProps) {
+interface ContainerProps {
+	isToggling: boolean;
+	cardMode: string;
+}
+
+function QuestionCard({ isToggling, mode, step, question }: QuestionCardProps) {
 	return (
-		<>
+		<Container cardMode={mode} isToggling={isToggling}>
 			<p>Question {step}.</p>
 			<p>{question}</p>
-		</>
+		</Container>
 	);
 }
+
+const Container = styled.div<ContainerProps>`
+	opacity: ${({ isToggling }) => (isToggling ? 0 : 1)};
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	transition: 0.3s;
+	${({ cardMode }) =>
+		cardMode === 'question'
+			? css(`
+        transform: rotateY(0);
+      `)
+			: css(`
+        transform: rotateY(180deg);
+      `)};
+
+	> p:first-of-type {
+		font-weight: bold;
+		color: var(--primary-color);
+		font-size: 20px;
+	}
+
+	> p:nth-of-type(2) {
+		padding: 10px;
+		font-weight: 500;
+		font-size: 18px;
+		color: var(--font-color);
+	}
+`;
 
 export default QuestionCard;

--- a/src/components/study/QuestionCard.tsx
+++ b/src/components/study/QuestionCard.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { css } from '@mui/material';
+import { mobileMediaQuery } from '../../utils/mediaQueries';
 
 interface QuestionCardProps {
 	isToggling: boolean;
@@ -42,6 +43,9 @@ const Container = styled.div<ContainerProps>`
 		font-weight: bold;
 		color: var(--primary-color);
 		font-size: 20px;
+		${mobileMediaQuery} {
+			font-size: 16px;
+		}
 	}
 
 	> p:nth-of-type(2) {
@@ -49,6 +53,9 @@ const Container = styled.div<ContainerProps>`
 		font-weight: 500;
 		font-size: 18px;
 		color: var(--font-color);
+		${mobileMediaQuery} {
+			font-size: 16px;
+		}
 	}
 `;
 

--- a/src/components/study/StudyHeader.tsx
+++ b/src/components/study/StudyHeader.tsx
@@ -32,9 +32,14 @@ function StudyHeader({ mode, step, title, total }: StudyHeaderProps) {
 
 const Container = styled.header`
 	${mobileMediaQuery} {
-		width: 100%;
+		width: 90%;
+		font-size: 14px;
 	}
 	${desktopMediaQuery} {
+		@media (max-width: 900px) {
+			width: 600px;
+		}
+
 		width: 800px;
 	}
 	display: flex;

--- a/src/components/study/StudyHeader.tsx
+++ b/src/components/study/StudyHeader.tsx
@@ -2,9 +2,10 @@ import styled from '@emotion/styled';
 import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import ImportContactsIcon from '@mui/icons-material/ImportContacts';
 import StyleIcon from '@mui/icons-material/Style';
+import { STUDY_MODE } from '../../constants';
 
 interface StudyHeaderProps {
-	mode: 'ALL' | 'WRONG';
+	mode: (typeof STUDY_MODE)[keyof typeof STUDY_MODE];
 	step: number;
 	title?: string;
 	total?: number;
@@ -16,7 +17,7 @@ function StudyHeader({ mode, step, title, total }: StudyHeaderProps) {
 			<div>
 				<ModeInfo>
 					<ImportContactsIcon color="inherit" />
-					<p>{mode === 'ALL' ? '전체' : '오답'} 학습모드</p>
+					<p>{mode === STUDY_MODE.ALL ? '전체' : '오답'} 학습모드</p>
 				</ModeInfo>
 				<h2>{title}</h2>
 			</div>

--- a/src/components/study/StudyHeader.tsx
+++ b/src/components/study/StudyHeader.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { desktopMediaQuery, mobileMediaQuery } from '../../utils/mediaQueries';
 import ImportContactsIcon from '@mui/icons-material/ImportContacts';
 import StyleIcon from '@mui/icons-material/Style';
+import { ProgressFraction } from '../../components';
 import { STUDY_MODE } from '../../constants';
 
 interface StudyHeaderProps {
@@ -23,10 +24,7 @@ function StudyHeader({ mode, step, title, total }: StudyHeaderProps) {
 			</div>
 			<ProgressBox>
 				<StyleIcon color="inherit" fontSize="large" />
-				<ProgressFraction>
-					<p>{step}</p>
-					<p>/{total}</p>
-				</ProgressFraction>
+				<ProgressFraction numerator={step} denominator={total} />
 			</ProgressBox>
 		</Container>
 	);
@@ -55,20 +53,6 @@ const ProgressBox = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-`;
-
-const ProgressFraction = styled.div`
-	display: flex;
-	margin-bottom: 10px;
-
-	> p {
-		font-weight: bold;
-		font-size: 25px;
-	}
-
-	> p:nth-of-type(2) {
-		color: #000;
-	}
 `;
 
 export default StudyHeader;

--- a/src/components/study/index.ts
+++ b/src/components/study/index.ts
@@ -1,8 +1,10 @@
 export { default as ToggleGuideCard } from './ToggleGuideCard';
-export { default as GhostCard } from './GhostCard';
-export { default as EmptyCard } from './EmptyCard';
+export { default as ProgressFraction } from './ProgressFraction';
 export { default as StudyHeader } from './StudyHeader';
 export { default as Card } from './Card';
+export { default as ControlBox } from './ControlBox';
+export { default as GhostCard } from './GhostCard';
+export { default as EmptyCard } from './EmptyCard';
 export { default as AnswerCard } from './AnswerCard';
 export { default as QuestionCard } from './QuestionCard';
-export { default as ControlBox } from './ControlBox';
+export { default as FinishedCard } from './FinishedCard';

--- a/src/components/study/index.ts
+++ b/src/components/study/index.ts
@@ -3,4 +3,6 @@ export { default as GhostCard } from './GhostCard';
 export { default as EmptyCard } from './EmptyCard';
 export { default as StudyHeader } from './StudyHeader';
 export { default as Card } from './Card';
+export { default as AnswerCard } from './AnswerCard';
+export { default as QuestionCard } from './QuestionCard';
 export { default as ControlBox } from './ControlBox';

--- a/src/constants/study.ts
+++ b/src/constants/study.ts
@@ -2,3 +2,5 @@ export const STUDY_STATUS = {
 	correct: 'correct',
 	wrong: 'wrong',
 } as const;
+
+export const MIN_SWIPE_DISTANCE = 100;

--- a/src/constants/study.ts
+++ b/src/constants/study.ts
@@ -3,4 +3,4 @@ export const STUDY_STATUS = {
 	wrong: 'wrong',
 } as const;
 
-export const MIN_SWIPE_DISTANCE = 100;
+export const MIN_SWIPE_DISTANCE = 50;

--- a/src/pages/Study.tsx
+++ b/src/pages/Study.tsx
@@ -97,7 +97,6 @@ function Study() {
 				step={step}
 				isFinished={isFinished}
 				current={data?.questionCardList[step - 1]}
-				studyMode={studyMode}
 				quizletId={quizletId}
 			/>
 		</Container>
@@ -110,6 +109,7 @@ const Container = styled.div`
 	flex-direction: column;
 	gap: 30px;
 	align-items: center;
+	overflow-x: hidden;
 `;
 
 const ProgressBar = styled(LinearProgress)`

--- a/src/pages/Study.tsx
+++ b/src/pages/Study.tsx
@@ -1,20 +1,30 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import styled from '@emotion/styled';
-import { useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 import { LinearProgress } from '@mui/material';
 import { StudyHeader, Card } from '../components';
 import { STUDY_MODE } from '../constants';
 import { desktopMediaQuery, mobileMediaQuery } from '../utils/mediaQueries';
 import { fetchStudyQuestionListQuery } from '../queries';
+import { useToastContext } from '../contexts/ToastContext';
+import { TOAST_MSG_TYPE, TOAST_TYPE } from '../constants/toast';
 
 function Study() {
+	const { addToast } = useToastContext();
 	const { quizletId, mode } = useParams();
-	const studyMode = STUDY_MODE[mode as 'ALL' | 'WRONG'];
+	const studyMode = mode as (typeof STUDY_MODE)[keyof typeof STUDY_MODE];
 	const [step, setStep] = useState(1);
-	const { data } = useQuery(
-		fetchStudyQuestionListQuery(quizletId as string, studyMode),
-	);
+
+	if (!quizletId || !mode || !(mode in STUDY_MODE)) {
+		addToast({
+			type: TOAST_TYPE.WARNING,
+			msg_type: TOAST_MSG_TYPE.NOT_FOUND,
+		});
+		return <Navigate to="/" />;
+	}
+
+	const { data } = useQuery(fetchStudyQuestionListQuery(quizletId, mode));
 
 	const goToNextCard = () => {
 		setStep((prev) => prev + 1);

--- a/src/pages/Study.tsx
+++ b/src/pages/Study.tsx
@@ -10,6 +10,9 @@ import { fetchStudyQuestionListQuery } from '../queries';
 import { useToastContext } from '../contexts/ToastContext';
 import { TOAST_MSG_TYPE, TOAST_TYPE } from '../constants/toast';
 
+let questionListToReview: string[] = [];
+let questionListToCorrect: string[] = [];
+
 function Study() {
 	const { addToast } = useToastContext();
 	const { quizletId, mode } = useParams();
@@ -27,17 +30,26 @@ function Study() {
 
 	const { data } = useQuery(fetchStudyQuestionListQuery(quizletId, mode));
 
-	const goToNextCard = () => {
-		if (step + 1 <= data?.questionCardList.length!) setStep((prev) => prev + 1);
-		else setIsFinished(true);
+	const goToNextCard = (isWrong: boolean, _id: string) => {
+		if (step + 1 <= data?.questionCardList.length!) {
+			setStep((prev) => prev + 1);
+			isWrong
+				? questionListToReview.push(_id)
+				: questionListToCorrect.push(_id);
+		} else {
+			setIsFinished(true);
+		}
 	};
 
-	const goToPrevCard = () => {
+	const goToPrevCard = (_id: string) => {
 		if (step === data?.questionCardList.length! && isFinished) {
 			setIsFinished(false);
 		} else if (step - 1 >= 0) {
 			setStep((prev) => prev - 1);
 		}
+
+		questionListToReview = questionListToReview.filter((id) => id !== _id);
+		questionListToCorrect = questionListToCorrect.filter((id) => id !== _id);
 	};
 
 	return (
@@ -58,6 +70,8 @@ function Study() {
 				step={step}
 				isFinished={isFinished}
 				current={data?.questionCardList[step - 1]}
+				questionListToReview={questionListToReview}
+				questionListToCorrect={questionListToCorrect}
 			/>
 		</Container>
 	);

--- a/src/pages/Study.tsx
+++ b/src/pages/Study.tsx
@@ -15,6 +15,7 @@ function Study() {
 	const { quizletId, mode } = useParams();
 	const studyMode = mode as (typeof STUDY_MODE)[keyof typeof STUDY_MODE];
 	const [step, setStep] = useState(1);
+	const [isFinished, setIsFinished] = useState(false);
 
 	if (!quizletId || !mode || !(mode in STUDY_MODE)) {
 		addToast({
@@ -27,11 +28,16 @@ function Study() {
 	const { data } = useQuery(fetchStudyQuestionListQuery(quizletId, mode));
 
 	const goToNextCard = () => {
-		setStep((prev) => prev + 1);
+		if (step + 1 <= data?.questionCardList.length!) setStep((prev) => prev + 1);
+		else setIsFinished(true);
 	};
 
 	const goToPrevCard = () => {
-		if (step - 1 >= 0) setStep((prev) => prev - 1);
+		if (step === data?.questionCardList.length! && isFinished) {
+			setIsFinished(false);
+		} else if (step - 1 >= 0) {
+			setStep((prev) => prev - 1);
+		}
 	};
 
 	return (
@@ -50,6 +56,7 @@ function Study() {
 				goToNextCard={goToNextCard}
 				goToPrevCard={goToPrevCard}
 				step={step}
+				isFinished={isFinished}
 				current={data?.questionCardList[step - 1]}
 			/>
 		</Container>


### PR DESCRIPTION
- AnswerCard, QuestionCard, ProgressFraction, FinishedCard 컴포넌트 구현
- GhostCard, EmptyCard 등 display 관련 로직 변경 
- ToggleGuideCard 컴포넌트 제거 
- (카드 swipe 관련) drag 이벤트 mouse 이벤트로 변경 
- 학습 종료 상태 (isFinished) 추가 
- questionListToReview/questionListToCorrect 상태/localStorage로 관리
- mobileMediaQuery, desktopMediaQuery 중간 (640px ~ 800px) 레이아웃 수정 
- GhostCard, FinishedCard 컴포넌트 방향 오류 수정 
- GhostCard 렌더시 생기는 하단 스크롤바 제거 
- 학습 결과 제출 API 연동 