### PR TITLE
Fix: 학습모드 카드 swipe 취소 로직 추가

### DIFF
--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -23,7 +23,7 @@ function AnswerCard({
 	link,
 }: AnswerCardProps) {
 	return (
-		<Container isToggling={isToggling}>
+		<Container isToggling={isToggling} id="card-contents">
 			<Question>
 				<span>Question {step}. </span>
 				{question}

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -9,6 +9,7 @@ interface AnswerCardProps {
 	question?: string;
 	answer?: string;
 	link?: string;
+	cancelSwipe: (event: React.MouseEvent | React.TouchEvent) => void;
 }
 
 interface ContainerProps {
@@ -21,9 +22,14 @@ function AnswerCard({
 	question,
 	answer,
 	link,
+	cancelSwipe,
 }: AnswerCardProps) {
 	return (
-		<Container isToggling={isToggling} id="card-contents">
+		<Container
+			isToggling={isToggling}
+			onMouseUp={cancelSwipe}
+			onTouchEnd={cancelSwipe}
+		>
 			<Question>
 				<span>Question {step}. </span>
 				{question}

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -57,6 +57,9 @@ const Container = styled.div<ContainerProps>`
 	gap: 20px;
 	position: relative;
 	transform: rotateY(180deg);
+	-webkit-user-select: none; /* Safari */
+	-ms-user-select: none; /* IE 10 and IE 11 */
+	user-select: none; /* Standard syntax */
 `;
 
 const Question = styled.p`
@@ -80,6 +83,7 @@ const Answer = styled.p`
 	font-size: 18px;
 	max-height: 80%;
 	overflow-y: auto;
+
 	${mobileMediaQuery} {
 		font-size: 16px;
 	}

--- a/src/components/study/AnswerCard.tsx
+++ b/src/components/study/AnswerCard.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
 import LanguageIcon from '@mui/icons-material/Language';
 import { mobileMediaQuery } from '../../utils/mediaQueries';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { useToastContext } from '../../contexts/ToastContext';
+import { TOAST_MSG_TYPE, TOAST_TYPE } from '../../constants/toast';
 
 interface AnswerCardProps {
 	isToggling: boolean;
@@ -24,6 +27,21 @@ function AnswerCard({
 	link,
 	cancelSwipe,
 }: AnswerCardProps) {
+	const { addToast } = useToastContext();
+
+	const copyToClipboard = () => {
+		const currentQuestion = `[질문 #${step}]: ${question}`;
+		const currentAnswer = `[정답]: ${answer}`;
+		const clipboardText = currentQuestion + '\n' + currentAnswer;
+
+		navigator.clipboard.writeText(clipboardText);
+
+		addToast({
+			type: TOAST_TYPE.SUCCESS,
+			msg_type: TOAST_MSG_TYPE.COPY_SUCCESS,
+		});
+	};
+
 	return (
 		<Container
 			isToggling={isToggling}
@@ -44,6 +62,7 @@ function AnswerCard({
 					<URL>{link}</URL>
 				</Link>
 			)}
+			<CopyIcon onClick={copyToClipboard} />
 		</Container>
 	);
 }
@@ -110,6 +129,23 @@ const Link = styled.a`
 const URL = styled.span`
 	font-style: italic;
 	color: gray;
+`;
+
+const CopyIcon = styled(ContentCopyIcon)`
+	display: flex;
+	gap: 10px;
+	align-items: center;
+	font-size: 22px;
+	position: absolute;
+	top: 0;
+	right: 0;
+	color: #999999;
+	cursor: pointer;
+	transition: 0.1s ease-in;
+
+	:hover {
+		color: black;
+	}
 `;
 
 export default AnswerCard;

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -92,6 +92,9 @@ function Card({
 	const endSwipe = (event: React.MouseEvent | React.TouchEvent) => {
 		if (!swipeStartX) return;
 
+		const selectedText = window.getSelection()?.toString();
+		if (selectedText) return;
+
 		const clientX =
 			event.type === 'touchend'
 				? lastTouch.current

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -80,7 +80,7 @@ function Card({
 		setSwipeStartX(clientX);
 	};
 
-	/** card 위에서 MouseUp이 발생한 경우 card를 swipe할 마음이 없다고 판단해서 swipe 로직 중단 */
+	/** mousedown 이벤트 후 Toggler 클릭시 카드 swipe 중단 */
 	const cancelSwipe = () => {
 		setSwipeStartX(null);
 	};
@@ -99,10 +99,10 @@ function Card({
 
 		isLeftSwipe.current = swipeStartX > clientX ? true : false;
 
-		setTimeout(() => setIsSwiping(false), 800);
 		setIsSwiping(true);
 		setSwipeStartX(null);
 		goToNextCard(isLeftSwipe.current, current?._id as string);
+		setTimeout(() => setIsSwiping(false), 800);
 		// cardMode 바꾸는데, transition 영향 안받는 방법?
 	};
 
@@ -112,10 +112,10 @@ function Card({
 
 		isLeftSwipe.current = direction === 'incorrect' ? true : false;
 
-		setTimeout(() => setIsSwiping(false), 800);
 		setIsSwiping(true);
 		setSwipeStartX(null);
 		goToNextCard(isLeftSwipe.current, current?._id as string);
+		setTimeout(() => setIsSwiping(false), 800);
 		// cardMode 바꾸는데, transition 영향 안받는 방법?
 	};
 

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -87,7 +87,8 @@ function Card({
 
 	/** mousedown/touch 이벤트로 인한 swipe 애니메이션 종료된 후의 로직  */
 	const endSwipe = (event: React.MouseEvent | React.TouchEvent) => {
-		if (!swipeStartX) return;
+		if (!swipeStartX || (event.target as HTMLElement).closest('#card-contents'))
+			return;
 
 		const clientX =
 			event.type === 'touchend'
@@ -102,6 +103,7 @@ function Card({
 		setIsSwiping(true);
 		setSwipeStartX(null);
 		goToNextCard(isLeftSwipe.current, current?._id as string);
+		// cardMode 바꾸는데, transition 영향 안받는 방법?
 	};
 
 	/** click 이벤트에 따라 카드 swipe */
@@ -114,6 +116,7 @@ function Card({
 		setIsSwiping(true);
 		setSwipeStartX(null);
 		goToNextCard(isLeftSwipe.current, current?._id as string);
+		// cardMode 바꾸는데, transition 영향 안받는 방법?
 	};
 
 	return (

--- a/src/components/study/Card.tsx
+++ b/src/components/study/Card.tsx
@@ -49,6 +49,7 @@ function Card({
 	const [cardMode, setCardMode] = useState<'question' | 'answer'>('question');
 	const lastTouch = useRef(0);
 	const isLeftSwipe = useRef(false);
+	const contentRef = useRef<null | HTMLDivElement>(null);
 
 	/** 질문 or 답안 보기 누르면 카드 내용 변경 */
 	const toggleCard = () => {
@@ -80,15 +81,16 @@ function Card({
 		setSwipeStartX(clientX);
 	};
 
-	/** mousedown 이벤트 후 Toggler 클릭시 카드 swipe 중단 */
-	const cancelSwipe = () => {
+	/** 드래그 중 카드 내부에서 mouseup/touchend 이벤트 발생시 카드 swipe 중단 */
+	const cancelSwipe = (event: React.MouseEvent | React.TouchEvent) => {
+		event.stopPropagation();
+
 		setSwipeStartX(null);
 	};
 
 	/** mousedown/touch 이벤트로 인한 swipe 애니메이션 종료된 후의 로직  */
 	const endSwipe = (event: React.MouseEvent | React.TouchEvent) => {
-		if (!swipeStartX || (event.target as HTMLElement).closest('#card-contents'))
-			return;
+		if (!swipeStartX) return;
 
 		const clientX =
 			event.type === 'touchend'
@@ -103,7 +105,6 @@ function Card({
 		setSwipeStartX(null);
 		goToNextCard(isLeftSwipe.current, current?._id as string);
 		setTimeout(() => setIsSwiping(false), 800);
-		// cardMode 바꾸는데, transition 영향 안받는 방법?
 	};
 
 	/** click 이벤트에 따라 카드 swipe */
@@ -116,12 +117,11 @@ function Card({
 		setSwipeStartX(null);
 		goToNextCard(isLeftSwipe.current, current?._id as string);
 		setTimeout(() => setIsSwiping(false), 800);
-		// cardMode 바꾸는데, transition 영향 안받는 방법?
 	};
 
 	return (
 		<Container onMouseUp={endSwipe}>
-			<CardContainer>
+			<CardContainer ref={contentRef}>
 				<MainCard
 					onTransitionEnd={displayCardText}
 					cardMode={cardMode}
@@ -145,6 +145,7 @@ function Card({
 							question={current?.question}
 							answer={current?.answer}
 							link={current?.link}
+							cancelSwipe={cancelSwipe}
 						/>
 					) : (
 						<QuestionCard
@@ -152,6 +153,7 @@ function Card({
 							mode={cardMode}
 							step={step}
 							question={current?.question}
+							cancelSwipe={cancelSwipe}
 						/>
 					)}
 				</MainCard>

--- a/src/components/study/GhostCard.tsx
+++ b/src/components/study/GhostCard.tsx
@@ -68,6 +68,10 @@ const Container = styled.div<ContainerProps>`
 	border: 1px solid #999999;
 	border-radius: 10px 10px 0 0;
 	padding: 5%;
+	-webkit-user-select: none; /* Safari */
+	-ms-user-select: none; /* IE 10 and IE 11 */
+	user-select: none; /* Standard syntax */
+
 	${mobileMediaQuery} {
 		width: 100%;
 		height: 400px;

--- a/src/components/study/QuestionCard.tsx
+++ b/src/components/study/QuestionCard.tsx
@@ -16,7 +16,7 @@ interface ContainerProps {
 
 function QuestionCard({ isToggling, mode, step, question }: QuestionCardProps) {
 	return (
-		<Container cardMode={mode} isToggling={isToggling}>
+		<Container cardMode={mode} isToggling={isToggling} id="card-contents">
 			<p>Question {step}.</p>
 			<p>{question}</p>
 		</Container>

--- a/src/components/study/QuestionCard.tsx
+++ b/src/components/study/QuestionCard.tsx
@@ -7,6 +7,7 @@ interface QuestionCardProps {
 	mode: string;
 	step: number;
 	question?: string;
+	cancelSwipe: (event: React.MouseEvent | React.TouchEvent) => void;
 }
 
 interface ContainerProps {
@@ -14,9 +15,20 @@ interface ContainerProps {
 	cardMode: string;
 }
 
-function QuestionCard({ isToggling, mode, step, question }: QuestionCardProps) {
+function QuestionCard({
+	isToggling,
+	mode,
+	step,
+	question,
+	cancelSwipe,
+}: QuestionCardProps) {
 	return (
-		<Container cardMode={mode} isToggling={isToggling} id="card-contents">
+		<Container
+			cardMode={mode}
+			isToggling={isToggling}
+			onMouseUp={cancelSwipe}
+			onTouchEnd={cancelSwipe}
+		>
 			<p>Question {step}.</p>
 			<p>{question}</p>
 		</Container>

--- a/src/components/study/QuestionCard.tsx
+++ b/src/components/study/QuestionCard.tsx
@@ -42,6 +42,10 @@ const Container = styled.div<ContainerProps>`
 	flex-direction: column;
 	gap: 20px;
 	transition: 0.3s;
+	-webkit-user-select: none; /* Safari */
+	-ms-user-select: none; /* IE 10 and IE 11 */
+	user-select: none; /* Standard syntax */
+
 	${({ cardMode }) =>
 		cardMode === 'question'
 			? css(`

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -14,6 +14,7 @@ export const TOAST_MSG_TYPE = {
 	SERVER_ERROR: 'SERVER_ERROR',
 	SUCCESS_DELETE: 'SUCCESS_DELETE',
 	FAIL_DELETE: 'FAIL_DELETE',
+	COPY_SUCCESS: 'COPY_SUCCESS',
 } as const;
 
 export const TOAST_MESSAGE = {
@@ -25,4 +26,5 @@ export const TOAST_MESSAGE = {
 	[TOAST_MSG_TYPE.SERVER_ERROR]: '나중에 다시 시도해주세요.',
 	[TOAST_MSG_TYPE.SUCCESS_DELETE]: '학습 세트가 삭제되었습니다.',
 	[TOAST_MSG_TYPE.FAIL_DELETE]: '학습 세트 삭제에 실패하였습니다.',
+	[TOAST_MSG_TYPE.COPY_SUCCESS]: '카드 내용이 복사되었습니다.',
 } as const;


### PR DESCRIPTION
- 카드 내용에서만 mouse 이벤트가 발생하는 경우 카드가 swipe 되지 않도록 수정 (내용 copy and paste를 위함일 수 있음) 
- AnswerCard/QuestionCard 내용 select 방지 
- AnswerCard에 copy and paste 버튼 추가 